### PR TITLE
Feat: Migrate to new Root Structure 

### DIFF
--- a/Frameworks/ZappApple/Files/Universal/Plugins/PluginManager/PluginsManager+LoadingStateMachineDataSource.swift
+++ b/Frameworks/ZappApple/Files/Universal/Plugins/PluginManager/PluginsManager+LoadingStateMachineDataSource.swift
@@ -13,26 +13,26 @@ extension PluginsManager: LoadingStateMachineDataSource {
     func preapareLoadingPluginStates() -> [LoadingState] {
         let loadPlugins = LoadingState()
         loadPlugins.stateHandler = loadPluginsGroup
-        loadPlugins.readableName = "Load General Plugins JSON"
+        loadPlugins.readableName = "<plugins-state-machine> Load General Plugins JSON"
 
         let analytics = LoadingState()
         analytics.stateHandler = prepareAnalyticsPlugins
         analytics.dependantStates = [loadPlugins.name]
-        analytics.readableName = "Prepare Analytics Plugins"
+        analytics.readableName = "<plugins-state-machine> Prepare Analytics Plugins"
 
         let push = LoadingState()
         push.stateHandler = preparePushPlugins
         push.dependantStates = [loadPlugins.name]
-        push.readableName = "Prepare Push Plugins"
+        push.readableName = "<plugins-state-machine> Prepare Push Plugins"
 
         let general = LoadingState()
         general.stateHandler = prepareGeneralPlugins
         general.dependantStates = [loadPlugins.name]
-        general.readableName = "Prepare General Plugins"
+        general.readableName = "<plugins-state-machine> Prepare General Plugins"
 
         let pluginsSessionStorageData = LoadingState()
         pluginsSessionStorageData.stateHandler = updatePluginSessionStorageData
-        pluginsSessionStorageData.readableName = "Plugins Session Storage"
+        pluginsSessionStorageData.readableName = "<plugins-state-machine> Plugins Session Storage"
         pluginsSessionStorageData.dependantStates = [loadPlugins.name]
         return [loadPlugins,
                 analytics,

--- a/Frameworks/ZappApple/Files/Universal/Plugins/PluginManager/PluginsManager.swift
+++ b/Frameworks/ZappApple/Files/Universal/Plugins/PluginManager/PluginsManager.swift
@@ -47,19 +47,18 @@ public class PluginsManager: NSObject {
             success ? successHandler() : failHandler()
         }
     }
-    
+
     func prepareGeneralPlugins(_ successHandler: @escaping StateCallBack,
-                            _ failHandler: @escaping StateCallBack) {
+                               _ failHandler: @escaping StateCallBack) {
         general.prepareManager { success in
             success ? successHandler() : failHandler()
         }
     }
-    
+
     func updatePluginSessionStorageData(_ successHandler: @escaping StateCallBack,
                                         _ failHandler: @escaping StateCallBack) {
         func sendConfigurationToSessionStorage(pluginModel: ZPPluginModel) {
             guard let configationJSON = pluginModel.configurationJSON as? [String: String] else {
-                successHandler()
                 return
             }
 

--- a/Frameworks/ZappApple/Files/Universal/Plugins/PluginManagerBase/PluginManagerBase.swift
+++ b/Frameworks/ZappApple/Files/Universal/Plugins/PluginManagerBase/PluginManagerBase.swift
@@ -44,6 +44,12 @@ public class PluginManagerBase: PluginManagerProtocol, PluginManagerControlFlowP
 
         if let pluginModels = pluginModels {
             var counter = pluginModels.count
+
+            guard counter > 0 else {
+                completion?(true)
+                return
+            }
+
             for pluginModel in pluginModels {
                 createProvider(pluginModel: pluginModel,
                                forceEnable: forceEnable) { _ in

--- a/Frameworks/ZappApple/Files/Universal/RootController/FacadeConnector/RootController+FacadeConnectorAnalyticsProtocol.swift
+++ b/Frameworks/ZappApple/Files/Universal/RootController/FacadeConnector/RootController+FacadeConnectorAnalyticsProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  RootViewController+ZAAppDelegateConnectorAnalyticsProtocol.swift
+//  RootController+ZAAppDelegateConnectorAnalyticsProtocol.swift
 //  ZappApple
 //
 //  Created by Anton Kononenko on 11/14/18.
@@ -9,7 +9,7 @@
 import Foundation
 import ZappCore
 
-extension RootViewController: FacadeConnectorAnalyticsProtocol {
+extension RootController: FacadeConnectorAnalyticsProtocol {
     public func sendEvent(name: String, parameters: Dictionary<String, Any>) {
         pluginsManager.analytics.sendEvent(name: name,
                                            parameters: parameters)

--- a/Frameworks/ZappApple/Files/Universal/RootController/FacadeConnector/RootController+FacadeConnectorAppDataProtocol.swift
+++ b/Frameworks/ZappApple/Files/Universal/RootController/FacadeConnector/RootController+FacadeConnectorAppDataProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  RootViewController+ZAAppDelegateConnectorGenericProtocol.swift
+//  RootController+ZAAppDelegateConnectorGenericProtocol.swift
 //  ZappApple
 //
 //  Created by Anton Kononenko on 11/14/18.
@@ -9,7 +9,7 @@
 import Foundation
 import ZappCore
 
-extension RootViewController: FacadeConnectorAppDataProtocol {
+extension RootController: FacadeConnectorAppDataProtocol {
     public func bundleName() -> String {
         return UIApplication.bundleName()
     }

--- a/Frameworks/ZappApple/Files/Universal/RootController/FacadeConnector/RootController+FacadeConnectorPlayerDependantProtocol.swift
+++ b/Frameworks/ZappApple/Files/Universal/RootController/FacadeConnector/RootController+FacadeConnectorPlayerDependantProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  RootViewController+FacadeConnectorPlayerDependantProtocol.swift
+//  RootController+FacadeConnectorPlayerDependantProtocol.swift
 //  ZappApple
 //
 //  Created by Anton Kononenko on 10/17/19.
@@ -9,7 +9,7 @@
 import Foundation
 import ZappCore
 
-extension RootViewController: FacadeConnectorPlayerDependantProtocol {
+extension RootController: FacadeConnectorPlayerDependantProtocol {
     public func playerDidFinishPlayItem(player: PlayerProtocol,
                                  completion: @escaping (Bool) -> Void) {
         pluginsManager.playerDependants.playerDidFinishPlayItem(player: player,

--- a/Frameworks/ZappApple/Files/Universal/RootController/FacadeConnector/RootController+FacadeConnectorPluginManagerProtocol.swift
+++ b/Frameworks/ZappApple/Files/Universal/RootController/FacadeConnector/RootController+FacadeConnectorPluginManagerProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  RootViewController+FacadeConnectorPluginManagerProtocol.swift
+//  RootController+FacadeConnectorPluginManagerProtocol.swift
 //  ZappApple
 //
 //  Created by Anton Kononenko on 10/15/19.
@@ -9,7 +9,7 @@
 import Foundation
 import ZappCore
 
-extension RootViewController: FacadeConnectorPluginManagerProtocol {
+extension RootController: FacadeConnectorPluginManagerProtocol {
     public func pluginModel(_ type: String) -> ZPPluginModel? {
         return PluginsManager.pluginModel(type)
     }

--- a/Frameworks/ZappApple/Files/Universal/RootController/FacadeConnector/RootController+FacadeConnectorPushProtocol.swift
+++ b/Frameworks/ZappApple/Files/Universal/RootController/FacadeConnector/RootController+FacadeConnectorPushProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  RootViewController+FacadeConnectorPushProtocol.swift
+//  RootController+FacadeConnectorPushProtocol.swift
 //  ZappApple
 //
 //  Created by Anton Kononenko on 1/28/20.
@@ -8,7 +8,7 @@
 import Foundation
 import ZappCore
 
-extension RootViewController: FacadeConnectorPushProtocol {
+extension RootController: FacadeConnectorPushProtocol {
     public func addTagsToDevice(_ tags: [String]?, completion: @escaping (Bool, [String]?) -> Void) {
         pluginsManager.push.addTagsToDevice(tags,
                                             completion: completion)

--- a/Frameworks/ZappApple/Files/Universal/RootController/FacadeConnector/RootController+FacadeConnectorStorageProtocol.swift
+++ b/Frameworks/ZappApple/Files/Universal/RootController/FacadeConnector/RootController+FacadeConnectorStorageProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  RootViewController+FacadeConnectorStorageProtocol.swift
+//  RootController+FacadeConnectorStorageProtocol.swift
 //  ZappApple
 //
 //  Created by Anton Kononenko on 10/8/19.
@@ -9,7 +9,7 @@
 import Foundation
 import ZappCore
 
-extension RootViewController: FacadeConnectorStorageProtocol {
+extension RootController: FacadeConnectorStorageProtocol {
     public func sessionStorageValue(for key: String, namespace: String?) -> String? {
         return SessionStorage.sharedInstance.get(key: key,
                                                  namespace: namespace)

--- a/Frameworks/ZappApple/Files/Universal/RootController/RootController+AppLoadingStateMachineDataSource.swift
+++ b/Frameworks/ZappApple/Files/Universal/RootController/RootController+AppLoadingStateMachineDataSource.swift
@@ -12,7 +12,7 @@ import ZappCore
 
 public let kMSAppCenterCheckForUpdatesNotification = "kMSAppCenterCheckForUpdatesNotification"
 
-extension RootViewController: LoadingStateMachineDataSource {
+extension RootController: LoadingStateMachineDataSource {
     func loadApplicationLoadingGroup(_ successHandler: @escaping StateCallBack,
                                      _ failHandler: @escaping StateCallBack) {
         splashViewController?.startAppLoading(completion: {
@@ -52,6 +52,7 @@ extension RootViewController: LoadingStateMachineDataSource {
         }
         userInterfaceLayer.prepareLayerForUse { [weak self] quickBrickViewController, error in
             if let quickBrickViewController = quickBrickViewController {
+                quickBrickViewController.view.backgroundColor = StylesHelper.color(forKey: CoreStylesKeys.backgroundColor)
                 self?.userInterfaceLayerContainerView.subviews.forEach { $0.removeFromSuperview() }
                 self?.userInterfaceLayerContainerView.addSubview(quickBrickViewController.view)
                 quickBrickViewController.view.matchParent()

--- a/Frameworks/ZappApple/Files/Universal/RootController/RootController+AppLoadingStateMachineDataSource.swift
+++ b/Frameworks/ZappApple/Files/Universal/RootController/RootController+AppLoadingStateMachineDataSource.swift
@@ -50,12 +50,11 @@ extension RootController: LoadingStateMachineDataSource {
             failHandler()
             return
         }
+
         userInterfaceLayer.prepareLayerForUse { [weak self] quickBrickViewController, error in
             if let quickBrickViewController = quickBrickViewController {
                 quickBrickViewController.view.backgroundColor = StylesHelper.color(forKey: CoreStylesKeys.backgroundColor)
-                self?.userInterfaceLayerContainerView.subviews.forEach { $0.removeFromSuperview() }
-                self?.userInterfaceLayerContainerView.addSubview(quickBrickViewController.view)
-                quickBrickViewController.view.matchParent()
+                self?.userInterfaceLayerViewController = quickBrickViewController
                 successHandler()
             } else if let error = error {
                 _ = OSLog(subsystem: error.localizedDescription,
@@ -68,20 +67,16 @@ extension RootController: LoadingStateMachineDataSource {
     public func stateMachineFinishedWork(with state: LoadingStateTypes) {
         if state == .success {
             appReadyForUse = true
-            userInterfaceLayerContainerView.isHidden = false
-            splashScreenContainerView.isHidden = true
+            makeInterfaceLayerAsRootViewContoroller()
             facadeConnector.analytics?.sendEvent?(name: CoreAnalyticsKeys.applicationWasLaunched,
                                                   parameters: [:])
             appDelegate?.handleDelayedEventsIfNeeded()
-            
+
             NotificationCenter.default.post(name: Notification.Name(kMSAppCenterCheckForUpdatesNotification),
                                             object: nil)
         } else {
-            userInterfaceLayerContainerView.isHidden = true
-            splashScreenContainerView.isHidden = false
-
             // TODO: After will be added multi language support should be take from localization string
-            splashViewController?.showErrorMessage("Loading failed. Please try again later")
+            showErrorMessage(message: "Loading failed. Please try again later")
         }
     }
 }

--- a/Frameworks/ZappApple/Files/Universal/RootController/RootController+ReachabilityManagerDelegate.swift
+++ b/Frameworks/ZappApple/Files/Universal/RootController/RootController+ReachabilityManagerDelegate.swift
@@ -26,17 +26,11 @@ extension RootController: ReachabilityManagerDelegate {
     }
     
     func showInternetError() {
-        userInterfaceLayerContainerView.isHidden = true
-        splashScreenContainerView.isHidden = false
-        
-        //TODO: After will be added multi language support should be take from localization string
-        splashViewController?.showErrorMessage("You are not connected to a network. Please use your device settings to connect to a network and try again.")
+        showErrorMessage(message: "You are not connected to a network. Please use your device settings to connect to a network and try again.")
     }
     
     func forceReloadApplication() {
-        userInterfaceLayerContainerView.isHidden = true
-        splashScreenContainerView.isHidden = false
-        self.userInterfaceLayerContainerView.subviews.forEach{$0.removeFromSuperview()}
+        makeSplashAsRootViewContoroller()
         reloadApplication()
     }
 

--- a/Frameworks/ZappApple/Files/Universal/RootController/RootController+ReachabilityManagerDelegate.swift
+++ b/Frameworks/ZappApple/Files/Universal/RootController/RootController+ReachabilityManagerDelegate.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Reachability
 
-extension RootViewController: ReachabilityManagerDelegate {
+extension RootController: ReachabilityManagerDelegate {
     
     func reachabilityChanged(connection: Reachability.Connection) {
         switch connection {

--- a/Frameworks/ZappApple/Files/Universal/RootController/RootController.swift
+++ b/Frameworks/ZappApple/Files/Universal/RootController/RootController.swift
@@ -11,9 +11,6 @@ import UIKit
 import ZappCore
 
 public class RootController: NSObject {
-    @IBOutlet var userInterfaceLayerContainerView: UIView!
-    @IBOutlet var splashScreenContainerView: UIView!
-
     public var appDelegate: AppDelegateProtocol?
     public var appReadyForUse: Bool = false
 
@@ -22,12 +19,11 @@ public class RootController: NSObject {
 
     var loadingStateMachine: LoadingStateMachine!
     public var userInterfaceLayer: UserInterfaceLayerProtocol?
+    public var userInterfaceLayerViewController: UIViewController?
+
     public var pluginsManager = PluginsManager()
 
-    lazy var splashViewController: SplashViewController? = {
-        return nil // Should retrieved from story board or similar implamentation
-//        return children.first { ($0 as? SplashViewController) != nil } as? SplashViewController
-    }()
+    var splashViewController: SplashViewController?
 
     public lazy var facadeConnector: FacadeConnector = {
         FacadeConnector(connectorProvider: self)
@@ -38,6 +34,8 @@ public class RootController: NSObject {
         if let userInterfaceLayer = UserInterfaceLayerManager.layerAdapter(launchOptions: appDelegate?.launchOptions) {
             self.userInterfaceLayer = userInterfaceLayer
         }
+
+        splashViewController = UIApplication.shared.delegate?.window??.rootViewController as? SplashViewController
 
         reachabilityManger = ReachabilityManager(delegate: self)
 
@@ -54,25 +52,43 @@ public class RootController: NSObject {
     func preapreLoadingStates() -> [LoadingState] {
         let splashState = LoadingState()
         splashState.stateHandler = loadApplicationLoadingGroup
-        splashState.readableName = "Show Splash Screen"
+        splashState.readableName = "<app-loader-state-machine> Show Splash Screen"
 
         let plugins = LoadingState()
         plugins.stateHandler = loadPluginsGroup
-        plugins.readableName = "Load plugins"
+        plugins.readableName = "<app-loader-state-machine> Load plugins"
 
         let styles = LoadingState()
         styles.stateHandler = loadStylesGroup
-        styles.readableName = "Load Styles"
+        styles.readableName = "<app-loader-state-machine> Load Styles"
 
         // Dependant states
         let userInterfaceLayer = LoadingState()
         userInterfaceLayer.stateHandler = loadUserInterfaceLayerGroup
-        userInterfaceLayer.readableName = "Prepare User Interface Layer"
+        userInterfaceLayer.readableName = "<app-loader-state-machine> Prepare User Interface Layer"
         return [splashState,
                 plugins,
                 styles,
                 userInterfaceLayer]
     }
-    
-    
+
+    func makeSplashAsRootViewContoroller() {
+        guard let window = UIApplication.shared.delegate?.window else {
+            return
+        }
+        window?.rootViewController = splashViewController
+    }
+
+    func makeInterfaceLayerAsRootViewContoroller() {
+        guard let window = UIApplication.shared.delegate?.window else {
+            return
+        }
+        window?.rootViewController = userInterfaceLayerViewController
+    }
+
+    func showErrorMessage(message: String) {
+        makeSplashAsRootViewContoroller()
+        // TODO: After will be added multi language support should be take from localization string
+        splashViewController?.showErrorMessage(message)
+    }
 }

--- a/Frameworks/ZappApple/Files/Universal/RootController/RootController.swift
+++ b/Frameworks/ZappApple/Files/Universal/RootController/RootController.swift
@@ -10,7 +10,7 @@ import Reachability
 import UIKit
 import ZappCore
 
-public class RootViewController: UIViewController {
+public class RootController: NSObject {
     @IBOutlet var userInterfaceLayerContainerView: UIView!
     @IBOutlet var splashScreenContainerView: UIView!
 
@@ -24,21 +24,21 @@ public class RootViewController: UIViewController {
     public var userInterfaceLayer: UserInterfaceLayerProtocol?
     public var pluginsManager = PluginsManager()
 
-    var splashViewController: SplashViewController? {
-        return children.first { ($0 as? SplashViewController) != nil } as? SplashViewController
-    }
+    lazy var splashViewController: SplashViewController? = {
+        return nil // Should retrieved from story board or similar implamentation
+//        return children.first { ($0 as? SplashViewController) != nil } as? SplashViewController
+    }()
 
     public lazy var facadeConnector: FacadeConnector = {
         FacadeConnector(connectorProvider: self)
     }()
 
-    public override func viewDidLoad() {
-        super.viewDidLoad()
+    public override init() {
+        super.init()
         if let userInterfaceLayer = UserInterfaceLayerManager.layerAdapter(launchOptions: appDelegate?.launchOptions) {
             self.userInterfaceLayer = userInterfaceLayer
         }
 
-        view.backgroundColor = StylesHelper.color(forKey: CoreStylesKeys.backgroundColor)
         reachabilityManger = ReachabilityManager(delegate: self)
 
         reloadApplication()

--- a/FrameworksData.plist
+++ b/FrameworksData.plist
@@ -5,7 +5,7 @@
 	<key>ZappApple</key>
 	<dict>
 		<key>version_id</key>
-		<string>0.3.0</string>
+		<string>0.4.0</string>
 	</dict>
 	<key>ZappCore</key>
 	<dict>


### PR DESCRIPTION
Was before: RootViewController was as Root of the window. This VC had two containers. Spash and UILayerPlugin, that was added regarding needs.
Now: RootViewController migrated to RootController. SplashVC and UILayerPluginVC added as Root of the window regarding the needs