### PR TITLE
feat(ui-tests): add accessibility identifier for the IMA player container

### DIFF
--- a/Frameworks/Plugins/ZappGoogleInteractiveMediaAds/Files/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
+++ b/Frameworks/Plugins/ZappGoogleInteractiveMediaAds/Files/Universal/GoogleInteractiveMediaAdsAdapter/GoogleInteractiveMediaAdsAdapter.swift
@@ -178,6 +178,7 @@ import ZappCore
                                        userContext: nil) {
             adRequest = request
             adsLoader?.requestAds(with: adRequest)
+            adDisplayContainer.adContainer.accessibilityIdentifier = adUrl
         }
     }
 }

--- a/Frameworks/Plugins/ZappGoogleInteractiveMediaAds/Files/ZappGoogleInteractiveMediaAds.podspec
+++ b/Frameworks/Plugins/ZappGoogleInteractiveMediaAds/Files/ZappGoogleInteractiveMediaAds.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = "ZappGoogleInteractiveMediaAds"
-	s.version = '0.10.1'
+	s.version = '0.10.2'
 	s.swift_versions = '5.1'
 
 	s.summary = "ZappGoogleInteractiveMediaAds"

--- a/FrameworksData.plist
+++ b/FrameworksData.plist
@@ -29,7 +29,7 @@
 	<key>ZappGoogleInteractiveMediaAds</key>
 	<dict>
 		<key>version_id</key>
-		<string>0.10.1</string>
+		<string>0.10.2</string>
 		<key>plugin</key>
 		<true/>
 	</dict>


### PR DESCRIPTION
This PR adds accessibility identifier for automation matters for the IMA player ad container when pre-roll, mid-roll or post roll are playing.

The used id is the url to the VAST. 
