### PR TITLE
fix: remove Screen flag in Chromecast manifest

### DIFF
--- a/Frameworks/Plugins/ZappChromecast/Files/manifests/manifest.config.js
+++ b/Frameworks/Plugins/ZappChromecast/Files/manifests/manifest.config.js
@@ -16,7 +16,6 @@ const baseManifest = {
     "A react native plugin that allows you to add chromecast support to a QuickBrick based project",
   type: "general",
   preload: true,
-  screen: true,
   react_native: true,
   identifier: "chromecast_qb",
   ui_builder_support: true,


### PR DESCRIPTION
This PR removes the screen flag in the Chromecast QB plugin manifest, as it mistakenly sets the plugin as a screen plugin every new push